### PR TITLE
src/GY21.h - improved error handling

### DIFF
--- a/src/GY21.h
+++ b/src/GY21.h
@@ -69,8 +69,8 @@ class GY21_
     }
     
     WireType* wire;
-    float _last_temp;
-    float _last_hum;
+    float _last_temp = NAN;
+    float _last_hum = NAN;
 };
 using GY21 = GY21_<TwoWire>;
 #endif


### PR DESCRIPTION
_last_temp and _last_hum initially set to NAN so that you can see if something is wrong with the sensor or I2C.

E.g. use use something like this:

```
/* Read humidity */
float RH = sensor.GY21_Humidity();
/* Read temperature in degree Celsius */
float Temp = sensor.GY21_Temperature();
/* Check if any reads failed */
if (isnan(RH) || isnan(Temp)) {
  /* do anything */
}

```
 